### PR TITLE
Pinned python package versions

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -12,12 +12,13 @@ build:
     - "libxext6"
     - "wget"
   python_packages:
-    - "git+https://github.com/huggingface/diffusers.git@ec068f9b5bf7c65f93125ec889e0ff1792a00da1#egg=diffusers"
+    - "diffusers==0.29.1"
     - "torch==2.2"
     - "transformers==4.41.2"
     - "accelerate==0.31.0"
-    - "sentencepiece"
-    - "protobuf"
+    - "sentencepiece==0.2.0"
+    - "protobuf==5.27.1"
+    - "numpy<2"
 
   run:
     - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/latest/download/pget_$(uname -s)_$(uname -m)" && chmod +x /usr/local/bin/pget


### PR DESCRIPTION
Gets rid of Numpy error
Updates diffusers version
And pins versions to other packages