### PR TITLE
add actions workflow for manual cog pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Push to Replicate
+ 
+on:
+  workflow_dispatch:
+    inputs:
+      model_name:
+        description: 'Enter the model name, like "alice/bunny-detector"'
+        required: true
+      git_branch:
+        description: 'Enter the git branch name to check out and push'
+        required: true
+        default: 'main'
+ 
+jobs:
+  push_to_replicate:
+    name: Push to Replicate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk pace
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          docker-images: false
+ 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_branch }}
+ 
+      - name: Setup Cog
+        uses: replicate/setup-cog@v2
+        with:
+          token: ${{ secrets.REPLICATE_API_TOKEN }}
+        
+      - name: Push to Replicate
+        run: cog push r8.im/${{ inputs.model_name }}


### PR DESCRIPTION
So we can do this:

![Screenshot 2024-06-25 at 21 34 05@2x](https://github.com/replicate/cog-stable-diffusion-3/assets/2289/008c1901-47b8-47a1-af3e-fe64a6e59107)
